### PR TITLE
Fix budget key references in latency cost evaluator

### DIFF
--- a/src/evalgate/evaluators/latency_cost.py
+++ b/src/evalgate/evaluators/latency_cost.py
@@ -15,9 +15,9 @@ def evaluate(fixtures: Dict[str, Dict[str, Any]],
         latencies.append(lat)
         costs.append(cost)
         if lat > budgets["p95_latency_ms"]:
-            fails.append(f"{name}: latency {lat}ms > {budgets[p95_latency_ms]}ms")
+            fails.append(f"{name}: latency {lat}ms > {budgets['p95_latency_ms']}ms")
         if cost > budgets["max_cost_usd_per_item"]:
-            fails.append(f"{name}: cost ${cost} > ${budgets[max_cost_usd_per_item]}")
+            fails.append(f"{name}: cost ${cost} > ${budgets['max_cost_usd_per_item']}")
     p95_latency = p95_fn(latencies)
     avg_cost = sum(costs) / (len(costs) or 1)
     lat_score = 1.0 if p95_latency <= budgets["p95_latency_ms"] else max(0.0, 1 - (p95_latency - budgets["p95_latency_ms"]) / budgets["p95_latency_ms"])


### PR DESCRIPTION
## Summary
- fix budget dictionary key usage in latency cost evaluator

## Testing
- `ruff check src/evalgate/evaluators/latency_cost.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a621fec874832b9577022f887fc30e