### PR TITLE
Add regex-based evaluator and config support

### DIFF
--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -15,10 +15,12 @@ class Outputs(BaseModel):
 
 class EvaluatorCfg(BaseModel):
     name: str
-    type: str  # "schema" | "category" | "budgets" | "llm"
+    type: str  # "schema" | "category" | "budgets" | "llm" | "regex"
     weight: float = 1.0
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None
+    pattern_field: Optional[str] = None  # name of expected field containing regex
+    pattern_path: Optional[str] = None  # path to JSON mapping of name->regex
     # LLM-specific fields
     provider: Optional[str] = None  # "openai" | "anthropic" | "azure" | "local"
     model: Optional[str] = None  # e.g. "gpt-4", "claude-3-5-sonnet-20241022"

--- a/src/evalgate/evaluators/regex_match.py
+++ b/src/evalgate/evaluators/regex_match.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import re
+from typing import Dict, Any, List, Tuple
+
+
+def evaluate(outputs: Dict[str, Any],
+             fixtures: Dict[str, Dict[str, Any]],
+             patterns: Dict[str, str]) -> Tuple[float, List[str]]:
+    """Check whether each output matches a given regex pattern.
+
+    Returns a tuple of (score, failures)."""
+    considered = 0
+    hits = 0
+    fails: List[str] = []
+    for name, out in outputs.items():
+        pattern = patterns.get(name)
+        if pattern is None:
+            # no pattern for this fixture; skip from scoring
+            continue
+        considered += 1
+        text = out if isinstance(out, str) else out.get("output", "") if isinstance(out, dict) else str(out)
+        if re.search(pattern, text):
+            hits += 1
+        else:
+            fails.append(f"{name}: pattern {pattern!r} not found in output")
+    total = considered or 1
+    return hits / total, fails


### PR DESCRIPTION
## Summary
- add regex_match evaluator for regex pattern checking
- support regex evaluator dispatch in CLI
- allow evaluator config to specify pattern_field or pattern_path

## Testing
- `uv run ruff check src/evalgate/cli.py src/evalgate/evaluators/regex_match.py`
- `uv run ruff check` *(fails: scripts/predict.py:3:1 E401, src/evalgate/util.py:3:1 E401, src/evalgate/util.py:20:18 E701)*
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a622ea85a4832b8c9372fe857e08a6