### PR TITLE
Add embedding similarity evaluator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ llm = [
   "openai>=1.0.0",
   "anthropic>=0.34.0"
 ]
+embedding = [
+  "sentence-transformers>=2.2"
+]
 dev = [
   "pytest>=8.0",
   "pytest-cov>=4.0",

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -15,13 +15,14 @@ class Outputs(BaseModel):
 
 class EvaluatorCfg(BaseModel):
     name: str
-    type: str  # "schema" | "category" | "budgets" | "llm"
+    type: str  # "schema" | "category" | "budgets" | "llm" | "embedding"
     weight: float = 1.0
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None
+    threshold: Optional[float] = 0.8  # cosine similarity threshold for embedding evaluator
     # LLM-specific fields
     provider: Optional[str] = None  # "openai" | "anthropic" | "azure" | "local"
-    model: Optional[str] = None  # e.g. "gpt-4", "claude-3-5-sonnet-20241022"
+    model: Optional[str] = None  # e.g. "gpt-4", "claude-3-5-sonnet-20241022" or embedding model name
     prompt_path: Optional[str] = None  # path to prompt template file
     api_key_env_var: Optional[str] = None  # env var name for API key
     base_url: Optional[str] = None  # for local/custom endpoints

--- a/src/evalgate/evaluators/embedding_similarity.py
+++ b/src/evalgate/evaluators/embedding_similarity.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple
+
+_model_cache: dict[str, Any] = {}
+
+def _get_model(name: str):
+    """Lazily load and cache a sentence embedding model."""
+    if name in _model_cache:
+        return _model_cache[name]
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as e:
+        raise ImportError(
+            "sentence-transformers package required for embedding evaluator."
+            " Install with: pip install sentence-transformers"
+        ) from e
+    model = SentenceTransformer(name)
+    _model_cache[name] = model
+    return model
+
+def evaluate(outputs: Dict[str, Dict[str, Any]],
+             fixtures: Dict[str, Dict[str, Any]],
+             field: str,
+             model_name: str,
+             threshold: float) -> Tuple[float, List[str]]:
+    """Evaluate embedding similarity between output and expected text."""
+    if not outputs:
+        return 1.0, []
+    model = _get_model(model_name)
+    try:
+        import numpy as np
+    except ImportError as e:
+        raise ImportError(
+            "numpy package required for embedding evaluator."
+            " Install with: pip install numpy"
+        ) from e
+    scores: List[float] = []
+    fails: List[str] = []
+    for name, out in outputs.items():
+        exp = fixtures.get(name, {}).get("expected", {})
+        exp_text = exp.get(field)
+        out_text = out.get(field)
+        if exp_text is None or out_text is None:
+            continue
+        vectors = model.encode([exp_text, out_text], normalize_embeddings=True)
+        sim = float(np.dot(vectors[0], vectors[1]))
+        scores.append(sim)
+        if sim < threshold:
+            fails.append(f"{name}: similarity {sim:.2f} below threshold {threshold:.2f}")
+    avg = sum(scores) / len(scores) if scores else 1.0
+    return avg, fails


### PR DESCRIPTION
## Summary
- add sentence-transformer based embedding evaluator with cosine similarity scoring
- expose evaluator type `embedding` with configurable threshold and model
- update CLI, config, and optional dependencies

## Testing
- `uv run ruff check src/evalgate/cli.py src/evalgate/config.py src/evalgate/evaluators/embedding_similarity.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a622f791e0832bb1ad010f9d9b2ec9