### PR TITLE
Add optional tables and plots to reports

### DIFF
--- a/src/evalgate/report.py
+++ b/src/evalgate/report.py
@@ -40,4 +40,24 @@ def render_markdown(result: Dict[str, Any]) -> str:
         f"- allow_regression: {result['gate']['allow_regression']} → {'✅' if (result.get('regression_ok', True)) else '❌'}",
         f"- evaluators_ok: → {'✅' if result.get('evaluators_ok', True) else '❌'}",
     ]
+
+    # Optional tables (e.g., confusion matrices)
+    for table in result.get("tables", []):
+        headers = table.get("headers", [])
+        rows = table.get("rows", [])
+        if not headers or not rows:
+            continue
+        lines += ["", f"**{table.get('title', 'Table')}**"]
+        lines.append("| " + " | ".join(headers) + " |")
+        lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+        for row in rows:
+            lines.append("| " + " | ".join(str(x) for x in row) + " |")
+
+    # Optional plots (links)
+    for plot in result.get("plots", []):
+        url = plot.get("url")
+        title = plot.get("title", "plot")
+        if url:
+            lines += ["", f"![{title}]({url})"]
+
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- allow report generator to embed Markdown tables and plot links
- capture classification confusion matrices during `run`

## Testing
- `ruff check src/evalgate/report.py src/evalgate/cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62652a728832bba3bf6ee921385c4