### PR TITLE
Add classification metrics evaluator with multi-label support

### DIFF
--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -17,6 +17,7 @@ from .evaluators import latency_cost as ev_budget
 from .evaluators import llm_judge as ev_llm
 from .evaluators import regex_match as ev_regex
 from .evaluators import rouge_bleu as ev_rb
+from .evaluators import classification_metrics as ev_cls
 from .util import list_paths, read_json, write_json
 from .store import load_baseline
 from .report import render_markdown
@@ -92,13 +93,14 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
             if not ev.model:
                 evaluator_errors.append(f"Evaluator '{ev.name}' missing required field: model")
                 continue
-        if ev.type in ("embedding", "rouge_bleu") and not ev.expected_field:
+        if ev.type in ("embedding", "rouge_bleu", "classification") and not ev.expected_field:
             evaluator_errors.append(f"Evaluator '{ev.name}' missing required field: expected_field")
             continue
         if ev.type == "regex" and not (ev.pattern_field or ev.pattern_path):
             evaluator_errors.append(f"Evaluator '{ev.name}' missing pattern_field or pattern_path")
             continue
         
+        extra = {}
         if ev.type == "schema":
             schema = read_json(ev.schema_path) if ev.schema_path else {}
             s, v = ev_schema.evaluate(o_map, schema)
@@ -164,10 +166,23 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
                 rprint(f"[red]Embedding evaluator {ev.name} failed: {e}[/red]")
                 evaluator_errors.append(f"Evaluator '{ev.name}' failed to run: {str(e)}")
                 continue
+        elif ev.type == "classification":
+            try:
+                s, v, m = ev_cls.evaluate(
+                    outputs=o_map,
+                    fixtures=f_map,
+                    field=ev.expected_field or "",
+                    multi_label=ev.multi_label or False,
+                )
+                extra["metrics"] = m
+            except Exception as e:
+                rprint(f"[red]Classification evaluator {ev.name} failed: {e}[/red]")
+                evaluator_errors.append(f"Evaluator '{ev.name}' failed to run: {str(e)}")
+                continue
         else:
             rprint(f"[yellow]Unknown evaluator type: {ev.type}[/yellow]")
             continue
-        scores.append({"name": ev.name, "score": float(s), "weight": ev.weight})
+        scores.append({"name": ev.name, "score": float(s), "weight": ev.weight, **extra})
         failures.extend(v)
 
     total_w = sum(x["weight"] for x in scores) or 1.0
@@ -191,9 +206,15 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
         rprint(f"[red]Gate failed: {len(evaluator_errors)} evaluator(s) failed to run[/red]")
     
     passed = overall >= cfg.gate.min_overall_score and regression_ok and evaluators_ok
+    score_items = []
+    for x in scores:
+        item = {"name": x["name"], "score": x["score"], "delta": deltas.get(x["name"])}
+        if "metrics" in x:
+            item["metrics"] = x["metrics"]
+        score_items.append(item)
     result = {
         "overall": overall,
-        "scores": [{"name": x["name"], "score": x["score"], "delta": deltas.get(x["name"])} for x in scores],
+        "scores": score_items,
         "failures": failures,
         "evaluator_errors": evaluator_errors,  # Separate from test failures
         "latency": latency,

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -15,7 +15,7 @@ class Outputs(BaseModel):
 
 class EvaluatorCfg(BaseModel):
     name: str
-    type: str  # "schema" | "category" | "budgets" | "llm" | "embedding" | "regex" | "rouge_bleu"
+    type: str  # "schema" | "category" | "budgets" | "llm" | "embedding" | "regex" | "rouge_bleu" | "classification"
     weight: float = 1.0
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None
@@ -23,6 +23,7 @@ class EvaluatorCfg(BaseModel):
     metric: Optional[str] = None  # metric for rouge_bleu evaluator: "bleu" | "rouge1" | "rouge2" | "rougeL"
     pattern_field: Optional[str] = None  # name of expected field containing regex
     pattern_path: Optional[str] = None  # path to JSON mapping of name->regex
+    multi_label: Optional[bool] = False  # treat field as list of labels
     # LLM-specific fields
     provider: Optional[str] = None  # "openai" | "anthropic" | "azure" | "local"
     model: Optional[str] = None  # e.g. "gpt-4", "claude-3-5-sonnet-20241022" or embedding model name

--- a/src/evalgate/evaluators/classification_metrics.py
+++ b/src/evalgate/evaluators/classification_metrics.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+
+def evaluate(
+    outputs: Dict[str, Dict[str, Any]],
+    fixtures: Dict[str, Dict[str, Any]],
+    field: str,
+    multi_label: bool = False,
+) -> Tuple[float, List[str], Dict[str, Any]]:
+    """Compute precision/recall/F1 for classification outputs.
+
+    Parameters
+    ----------
+    outputs: mapping of fixture name to predicted output
+    fixtures: mapping of fixture name to fixture with ``expected`` values
+    field: name of field containing the label(s)
+    multi_label: if True, treat labels as lists and compute multi-label metrics
+
+    Returns
+    -------
+    Tuple containing overall F1 score, list of failures, and metrics dict with
+    precision, recall, F1, and the confusion matrix.
+    """
+    if not outputs:
+        return 1.0, [], {"precision": 1.0, "recall": 1.0, "f1": 1.0, "confusion_matrix": {}}
+
+    confusion: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    fails: List[str] = []
+    tp = fp = fn = 0
+
+    for name, out in outputs.items():
+        exp_val = fixtures.get(name, {}).get("expected", {}).get(field)
+        pred_val = out.get(field)
+        if exp_val is None or pred_val is None:
+            # skip items without ground truth or prediction
+            continue
+
+        if multi_label:
+            exp_set = set(exp_val)
+            pred_set = set(pred_val)
+            for lbl in exp_set:
+                if lbl in pred_set:
+                    confusion[lbl][lbl] += 1
+                else:
+                    confusion[lbl]["__none__"] += 1
+            for lbl in pred_set - exp_set:
+                confusion["__none__"][lbl] += 1
+            tp += len(exp_set & pred_set)
+            fp += len(pred_set - exp_set)
+            fn += len(exp_set - pred_set)
+            if exp_set != pred_set:
+                fails.append(
+                    f"{name}: expected {sorted(exp_set)}, got {sorted(pred_set)}"
+                )
+        else:
+            exp_label = exp_val
+            pred_label = pred_val
+            confusion[exp_label][pred_label] += 1
+            if exp_label != pred_label:
+                fails.append(f"{name}: expected {exp_label!r}, got {pred_label!r}")
+                fp += 1
+                fn += 1
+            else:
+                tp += 1
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+
+    metrics = {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "confusion_matrix": {exp: dict(preds) for exp, preds in confusion.items()},
+    }
+    return f1, fails, metrics

--- a/tests/test_classification_metrics.py
+++ b/tests/test_classification_metrics.py
@@ -1,0 +1,40 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import classification_metrics as cm
+
+
+def test_single_label_metrics():
+    outputs = {
+        "a": {"label": "cat"},
+        "b": {"label": "dog"},
+        "c": {"label": "cat"},
+    }
+    fixtures = {
+        "a": {"expected": {"label": "cat"}},
+        "b": {"expected": {"label": "cat"}},
+        "c": {"expected": {"label": "dog"}},
+    }
+    f1, fails, metrics = cm.evaluate(outputs, fixtures, field="label")
+    assert round(metrics["precision"], 3) == 0.333
+    assert round(metrics["recall"], 3) == 0.333
+    assert round(f1, 3) == 0.333
+    assert len(fails) == 2
+
+
+def test_multi_label_metrics():
+    outputs = {
+        "a": {"labels": ["cat", "pet"]},
+        "b": {"labels": ["car"]},
+    }
+    fixtures = {
+        "a": {"expected": {"labels": ["cat", "feline"]}},
+        "b": {"expected": {"labels": ["car", "vehicle"]}},
+    }
+    f1, fails, metrics = cm.evaluate(outputs, fixtures, field="labels", multi_label=True)
+    assert round(metrics["precision"], 3) == 0.667
+    assert round(metrics["recall"], 3) == 0.5
+    assert round(f1, 3) == 0.571
+    assert len(fails) == 2


### PR DESCRIPTION
## Summary
- add `classification_metrics` evaluator for confusion matrix, precision/recall/F1
- support multi-label classification via config
- wire evaluator into CLI and results handling
- test single and multi-label metric computation

## Testing
- `ruff check src/evalgate/evaluators/classification_metrics.py`
- `ruff check src/evalgate/config.py`
- `ruff check src/evalgate/cli.py`
- `ruff check tests/test_classification_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a627267b2c832b8150aa55fa68a013