### PR TITLE
Add required fields evaluator

### DIFF
--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -17,6 +17,7 @@ from .evaluators import latency_cost as ev_budget
 from .evaluators import llm_judge as ev_llm
 from .evaluators import regex_match as ev_regex
 from .evaluators import rouge_bleu as ev_rb
+from .evaluators import required_fields as ev_req
 from .util import list_paths, read_json, write_json
 from .store import load_baseline
 from .report import render_markdown
@@ -192,6 +193,8 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
                 rprint(f"[red]Embedding evaluator {ev.name} failed: {e}[/red]")
                 evaluator_errors.append(f"Evaluator '{ev.name}' failed to run: {str(e)}")
                 continue
+        elif ev.type == "required_fields":
+            s, v = ev_req.evaluate(o_map, f_map)
         else:
             rprint(f"[yellow]Unknown evaluator type: {ev.type}[/yellow]")
             continue

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -15,7 +15,7 @@ class Outputs(BaseModel):
 
 class EvaluatorCfg(BaseModel):
     name: str
-    type: str  # "schema" | "category" | "budgets" | "llm" | "embedding" | "regex" | "rouge_bleu"
+    type: str  # "schema" | "category" | "budgets" | "llm" | "embedding" | "regex" | "rouge_bleu" | "required_fields"
     weight: float = 1.0
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None

--- a/src/evalgate/evaluators/required_fields.py
+++ b/src/evalgate/evaluators/required_fields.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple
+
+
+def evaluate(outputs: Dict[str, Dict[str, Any]],
+             fixtures: Dict[str, Dict[str, Any]]) -> Tuple[float, List[str]]:
+    """Verify required fields are present with non-empty values.
+
+    Each fixture may list fields under ``expected``. For every listed field, the
+    corresponding output must contain the field with a non-empty value. The
+    evaluator returns a tuple of ``(score, failures)`` where ``score`` is the
+    fraction of required fields present and ``failures`` details missing or
+    empty fields.
+    """
+    total = 0
+    ok = 0
+    failures: List[str] = []
+    for name, out in outputs.items():
+        required = fixtures.get(name, {}).get("expected", {})
+        if not required:
+            continue  # nothing to validate for this fixture
+        for field in required.keys():
+            total += 1
+            val = out.get(field)
+            if val is None or val == "" or val == [] or val == {}:
+                failures.append(f"{name}: missing or empty field '{field}'")
+            else:
+                ok += 1
+    total = total or 1
+    return ok / total, failures


### PR DESCRIPTION
## Summary
- add evaluator to ensure required output fields are present and non-empty
- wire up `required_fields` evaluator type in CLI and config

## Testing
- `uv run ruff check src/evalgate/evaluators/required_fields.py src/evalgate/config.py src/evalgate/cli.py`
- `uv run ruff check src` *(fails: src/evalgate/util.py lint issues)*
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a627b534f0832bb1b39b14f791bfc7