### PR TITLE
Use enum for evaluator type

### DIFF
--- a/src/evalgate/templates/default_config.yml
+++ b/src/evalgate/templates/default_config.yml
@@ -3,11 +3,11 @@ budgets: { p95_latency_ms: 1200, max_cost_usd_per_item: 0.03 }
 fixtures: { path: "eval/fixtures/**/*.json" }
 outputs:  { path: ".evalgate/outputs/**/*.json" }
 evaluators:
-  - { name: json_formatting, type: schema, schema_path: "eval/schemas/queue_item.json", weight: 0.3 }
-  - { name: priority_accuracy, type: category, expected_field: "priority", weight: 0.3 }
-  - { name: latency_cost, type: budgets, weight: 0.2 }
+  - { name: json_formatting, type: SCHEMA, schema_path: "eval/schemas/queue_item.json", weight: 0.3 }
+  - { name: priority_accuracy, type: CATEGORY, expected_field: "priority", weight: 0.3 }
+  - { name: latency_cost, type: BUDGETS, weight: 0.2 }
   # Uncomment and configure with your API key to enable LLM evaluation:
-  # - { name: content_quality, type: llm, provider: openai, model: "gpt-4", prompt_path: "eval/prompts/quality_judge.txt", api_key_env_var: "OPENAI_API_KEY", weight: 0.2 }
+  # - { name: content_quality, type: LLM, provider: openai, model: "gpt-4", prompt_path: "eval/prompts/quality_judge.txt", api_key_env_var: "OPENAI_API_KEY", weight: 0.2 }
 gate: { min_overall_score: 0.90, allow_regression: false }
 report: { pr_comment: true, artifact_path: ".evalgate/results.json" }
 baseline: { ref: "origin/main" }


### PR DESCRIPTION
## Summary
- add `EvaluatorType` enum to constrain evaluator kinds
- type `EvaluatorCfg.type` with the new enum
- switch default YAML template to enum names

## Testing
- `ruff check src/evalgate/config.py`
- `yamllint -d '{extends: default, rules: {document-start: disable, line-length: {max: 200, level: warning}, colons: disable, braces: disable}}' src/evalgate/templates/default_config.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62ac41fe8832bb97c5192d1cab96b