### PR TITLE
feat: enhance markdown report

### DIFF
--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -289,12 +289,15 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
         rprint("[green]EvalGate PASSED[/green]")
 
 @app.command()
-def report(pr: bool = typer.Option(False, "--pr", help="(future) post PR comment via API"),
-           summary: bool = typer.Option(False, "--summary", help="Write to $GITHUB_STEP_SUMMARY"),
-           artifact: str = typer.Option(".evalgate/results.json", help="Path to results JSON")):
+def report(
+    pr: bool = typer.Option(False, "--pr", help="(future) post PR comment via API"),
+    summary: bool = typer.Option(False, "--summary", help="Write to $GITHUB_STEP_SUMMARY"),
+    artifact: str = typer.Option(".evalgate/results.json", help="Path to results JSON"),
+    max_failures: int = typer.Option(20, "--max-failures", help="Max failures to show"),
+):
     """Render a markdown summary from results."""
     data = read_json(artifact)
-    md = render_markdown(data)
+    md = render_markdown(data, max_failures=max_failures)
     if summary and "GITHUB_STEP_SUMMARY" in os.environ:
         pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text(md, encoding="utf-8")
     else:

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.report import render_markdown
+
+
+def test_render_markdown_max_failures_and_plots():
+    result = {
+        "overall": 0.9,
+        "scores": [{"name": "metric1", "score": 0.9, "delta": 0.1}],
+        "failures": [f"f{i}" for i in range(6)],
+        "evaluator_errors": [],
+        "latency": None,
+        "cost": None,
+        "gate": {"min_overall_score": 0.5, "allow_regression": True, "passed": True},
+        "regression_ok": True,
+        "evaluators_ok": True,
+        "plots": [{"title": "trend", "sparkline": "s.png", "url": "p.png"}],
+    }
+    md = render_markdown(result, max_failures=5)
+    assert "… +1 more" in md
+    assert "| Metric | Δ vs baseline |" in md
+    assert "[![trend](s.png)](p.png)" in md


### PR DESCRIPTION
## Summary
- allow configuring max failures in report CLI and renderer
- show baseline deltas table and optional sparkline/plot links in markdown report
- test markdown rendering features

## Testing
- `ruff check src/evalgate/report.py src/evalgate/cli.py tests/test_report_markdown.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62b621738832b94d9e316d6622c14