### PR TITLE
Add evaluator unit tests

### DIFF
--- a/tests/test_category_match.py
+++ b/tests/test_category_match.py
@@ -1,0 +1,33 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import category_match as cm
+
+
+def test_category_match_happy_and_failures():
+    outputs = {"a": {"category": "x"}, "b": {"category": "y"}}
+    fixtures = {
+        "a": {"expected": {"category": "x"}},
+        "b": {"expected": {"category": "x"}},
+    }
+    score, fails = cm.evaluate(outputs, fixtures, "category")
+    assert score == 0.5
+    assert len(fails) == 1
+
+
+def test_missing_expected_field_results_zero_score():
+    outputs = {"a": {"category": "x"}}
+    fixtures = {"a": {"expected": {}}}
+    score, fails = cm.evaluate(outputs, fixtures, "category")
+    assert score == 0.0
+    assert fails == []
+
+
+def test_missing_output_field_fails():
+    outputs = {"a": {}}
+    fixtures = {"a": {"expected": {"category": "x"}}}
+    score, fails = cm.evaluate(outputs, fixtures, "category")
+    assert score == 0.0
+    assert len(fails) == 1

--- a/tests/test_classification_metrics.py
+++ b/tests/test_classification_metrics.py
@@ -38,3 +38,20 @@ def test_multi_label_metrics():
     assert round(metrics["recall"], 3) == 0.5
     assert round(f1, 3) == 0.571
     assert len(fails) == 2
+
+def test_missing_labels_are_skipped():
+    outputs = {"a": {}, "b": {"label": "cat"}}
+    fixtures = {
+        "a": {"expected": {"label": "dog"}},
+        "b": {"expected": {"label": "cat"}},
+    }
+    f1, fails, metrics = cm.evaluate(outputs, fixtures, field="label")
+    assert f1 == 1.0
+    assert fails == []
+
+
+def test_empty_outputs_return_perfect_score():
+    f1, fails, metrics = cm.evaluate({}, {"x": {"expected": {"label": "cat"}}}, field="label")
+    assert f1 == 1.0
+    assert metrics["precision"] == 1.0
+    assert fails == []

--- a/tests/test_embedding_similarity.py
+++ b/tests/test_embedding_similarity.py
@@ -1,0 +1,42 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import embedding_similarity as es
+
+
+class DummyModel:
+    def encode(self, texts, normalize_embeddings=True):
+        if texts[1] == "match":
+            return [[1.0, 0.0], [1.0, 0.0]]
+        return [[1.0, 0.0], [0.0, 1.0]]
+
+
+class DummyNumpy(SimpleNamespace):
+    @staticmethod
+    def dot(a, b):
+        return sum(x * y for x, y in zip(a, b))
+
+
+def test_embedding_similarity_scoring(monkeypatch):
+    monkeypatch.setattr(es, "_get_model", lambda name: DummyModel())
+    monkeypatch.setitem(sys.modules, "numpy", DummyNumpy())
+    outputs = {"a": {"text": "match"}, "b": {"text": "mismatch"}}
+    fixtures = {
+        "a": {"expected": {"text": "match"}},
+        "b": {"expected": {"text": "match"}},
+    }
+    score, fails = es.evaluate(outputs, fixtures, field="text", model_name="dummy", threshold=0.8)
+    assert round(score, 2) == 0.5
+    assert len(fails) == 1
+
+
+def test_embedding_similarity_dependency_error(monkeypatch):
+    def raiser(name):
+        raise ImportError("sentence-transformers package required")
+    monkeypatch.setattr(es, "_get_model", raiser)
+    with pytest.raises(ImportError):
+        es.evaluate({"a": {"text": "x"}}, {"a": {"expected": {"text": "x"}}}, field="text", model_name="dummy", threshold=0.5)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import json_schema as js
+
+
+def test_json_schema_valid_and_invalid():
+    schema = {
+        "type": "object",
+        "properties": {"age": {"type": "number"}},
+        "required": ["age"],
+    }
+    outputs = {"a": {"age": 5}, "b": {}}
+    score, violations = js.evaluate(outputs, schema)
+    assert score == 0.5
+    assert len(violations) == 1
+
+
+def test_json_schema_missing_field_violation():
+    schema = {"type": "object", "required": ["name"]}
+    outputs = {"a": {}}
+    score, violations = js.evaluate(outputs, schema)
+    assert score == 0.0
+    assert violations

--- a/tests/test_latency_cost.py
+++ b/tests/test_latency_cost.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import latency_cost as lc
+
+
+def test_latency_cost_scoring_and_fails():
+    fixtures = {
+        "a": {"meta": {"latency_ms": 80, "cost_usd": 0.1}},
+        "b": {"meta": {"latency_ms": 120, "cost_usd": 0.2}},
+    }
+    budgets = {"p95_latency_ms": 100, "max_cost_usd_per_item": 0.15}
+    score, fails, p95, avg = lc.evaluate(fixtures, budgets)
+    assert round(score, 2) == 0.9
+    assert len(fails) == 2
+    assert p95 == 120
+    assert round(avg, 2) == 0.15
+
+
+def test_latency_cost_missing_meta_defaults_zero():
+    fixtures = {"a": {}}
+    budgets = {"p95_latency_ms": 100, "max_cost_usd_per_item": 1.0}
+    score, fails, p95, avg = lc.evaluate(fixtures, budgets)
+    assert score == 1.0
+    assert fails == []
+    assert p95 == 0.0
+    assert avg == 0.0

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,0 +1,54 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import llm_judge as lj
+
+
+def test_llm_judge_happy(monkeypatch, tmp_path):
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("{input}\n{output}")
+    monkeypatch.setattr(lj, "_call_openai", lambda *a, **k: "Score: 0.8")
+    monkeypatch.setenv("OPENAI_KEY", "x")
+    outputs = {"a": {"text": "hi"}}
+    fixtures = {"a": {"input": {"q": "?"}, "expected": {"text": "hi"}}}
+    score, details = lj.evaluate(
+        outputs,
+        fixtures,
+        provider="openai",
+        model="gpt",
+        prompt_path=str(prompt),
+        api_key_env_var="OPENAI_KEY",
+    )
+    assert score == 0.8
+    assert details == []
+
+
+def test_llm_judge_missing_api_key(tmp_path):
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("test")
+    outputs = {"a": {}}
+    fixtures = {"a": {}}
+    with pytest.raises(ValueError):
+        lj.evaluate(outputs, fixtures, provider="openai", model="gpt", prompt_path=str(prompt), api_key_env_var="MISSING")
+
+
+def test_llm_judge_dependency_error(monkeypatch, tmp_path):
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("test")
+    def raiser(*args, **kwargs):
+        raise ImportError("openai missing")
+    monkeypatch.setattr(lj, "_call_openai", raiser)
+    monkeypatch.setenv("OPENAI_KEY", "x")
+    score, details = lj.evaluate(
+        {"a": {}},
+        {"a": {}},
+        provider="openai",
+        model="gpt",
+        prompt_path=str(prompt),
+        api_key_env_var="OPENAI_KEY",
+    )
+    assert score == 0.0
+    assert "Evaluation failed" in details[0]

--- a/tests/test_regex_match.py
+++ b/tests/test_regex_match.py
@@ -1,0 +1,20 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import regex_match as rm
+
+
+def test_regex_match_scoring():
+    outputs = {"a": "hello world", "b": {"output": "foo"}}
+    patterns = {"a": "hello", "b": "bar"}
+    score, fails = rm.evaluate(outputs, {}, patterns)
+    assert score == 0.5
+    assert len(fails) == 1
+
+
+def test_regex_match_missing_pattern_skipped():
+    score, fails = rm.evaluate({"a": "hi"}, {}, {})
+    assert score == 0.0
+    assert fails == []

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import required_fields as rf
+
+
+def test_required_fields_scoring():
+    outputs = {"a": {"x": 1}, "b": {"x": 1}}
+    fixtures = {
+        "a": {"expected": {"x": 0}},
+        "b": {"expected": {"x": 0, "y": 0}},
+    }
+    score, fails = rf.evaluate(outputs, fixtures)
+    assert round(score, 2) == 0.67
+    assert len(fails) == 1
+
+
+def test_required_fields_missing_output_field():
+    outputs = {"a": {}}
+    fixtures = {"a": {"expected": {"x": 0}}}
+    score, fails = rf.evaluate(outputs, fixtures)
+    assert score == 0.0
+    assert len(fails) == 1

--- a/tests/test_rouge_bleu.py
+++ b/tests/test_rouge_bleu.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+import builtins
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import rouge_bleu as rb
+
+
+def test_bleu_scoring():
+    outputs = {"a": {"text": "hello world"}}
+    fixtures = {"a": {"expected": {"text": "hello world"}}}
+    score, fails = rb.evaluate(outputs, fixtures, field="text", metric="bleu")
+    assert round(score, 2) == 1.0
+    assert "BLEU" in fails[0]
+
+
+def test_rouge_dependency_error(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "rouge_score":
+            raise ImportError("missing")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError):
+        rb.evaluate({"a": {"text": "a"}}, {"a": {"expected": {"text": "b"}}}, field="text", metric="rouge1")
+
+
+def test_rouge_bleu_missing_fields_skip():
+    score, fails = rb.evaluate({}, {}, field="text", metric="bleu")
+    assert score == 1.0
+    assert fails == []


### PR DESCRIPTION
## Summary
- add unit tests for each evaluator module
- mock LLM and embedding calls for offline testing
- cover dependency and missing field edge cases

## Testing
- `ruff check tests/test_embedding_similarity.py tests/test_llm_judge.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62b698390832b99d7f183799544f4