### PR TITLE
docs: document custom evaluator and baseline refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ evalgate run --config .github/evalgate.yml
 # The selftest should pass with a score of 1.0
 ```
 
+If your changes modify the expected outputs, remember to [refresh your baseline](README.md#refreshing-your-baseline) on the `main` branch so future runs compare against the updated results.
+
 ### Adding New Tests
 
 When adding new evaluators or features:
@@ -170,7 +172,7 @@ src/evalgate/
 
 ### Adding New Evaluators
 
-To add a new evaluator type:
+To add a new evaluator type (using the plugin registry), see [Writing a custom evaluator](README.md#writing-a-custom-evaluator) for an example. In summary:
 
 1. **Create a new module** in `src/evalgate/evaluators/`
 2. **Implement the `evaluate` function:**


### PR DESCRIPTION
## Summary
- document how to write a custom evaluator using the plugin registry
- explain how to refresh the baseline for regression checks
- link contributing guide to these new README sections

## Testing
- `uvx ruff check` (fails: E401 multiple imports)
- `uvx pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62b775e10832b90120b482ab39950