### PR TITLE
Add conversation flow evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,24 @@ Or integrate directly in your existing workflow:
     path: .evalgate/results.json
     retention-days: 30
 ```
+```
+
+## Conversation Flow Evaluator
+
+Validate multi-turn conversations by checking the final message and turn count.
+
+```yaml
+evaluators:
+  - name: convo_flow
+    type: conversation
+    expected_final_field: content
+    max_turns: 5
+    weight: 0.2
+```
+
+Each output must provide a `messages` array. The evaluator compares the last
+message's `content` against the fixture's `expected.content` and fails if the
+conversation exceeds `max_turns`.
 
 ## Writing a custom evaluator
 

--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -23,6 +23,7 @@ from .evaluators import (
     rouge_bleu as _rouge_bleu,  # noqa: F401
     required_fields as _required_fields,  # noqa: F401
     classification_metrics as _classification_metrics,  # noqa: F401
+    conversation_flow as _conversation_flow,  # noqa: F401
 )
 from .util import list_paths, read_json, write_json
 from .fixture_generator import generate_suite

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -26,6 +26,7 @@ class EvaluatorType(str, Enum):
     ROUGE_BLEU = "rouge_bleu"
     REQUIRED_FIELDS = "required_fields"
     CLASSIFICATION = "classification"
+    CONVERSATION = "conversation"
 
 
 class EvaluatorCfg(BaseModel):
@@ -34,6 +35,8 @@ class EvaluatorCfg(BaseModel):
     weight: float = 1.0
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None
+    expected_final_field: Optional[str] = None
+    max_turns: Optional[int] = None
     threshold: Optional[float] = 0.8  # cosine similarity threshold for embedding evaluator
     metric: Optional[str] = None  # metric for rouge_bleu evaluator: "bleu" | "rouge1" | "rouge2" | "rougeL"
     pattern_field: Optional[str] = None  # name of expected field containing regex

--- a/src/evalgate/evaluators/conversation_flow.py
+++ b/src/evalgate/evaluators/conversation_flow.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from .base import register
+
+
+def evaluate(
+    outputs: Dict[str, Dict[str, Any]],
+    fixtures: Dict[str, Dict[str, Any]],
+    expected_field: str,
+    max_turns: int | None = None,
+) -> Tuple[float, List[str]]:
+    """Validate conversation flow and final message content.
+
+    Parameters
+    ----------
+    outputs:
+        Mapping of item name to output data containing ``messages`` list.
+    fixtures:
+        Mapping of item name to fixture data with ``expected`` section.
+    expected_field:
+        Field in final message to compare against the expected value.
+    max_turns:
+        Optional maximum number of allowed messages in the conversation.
+    """
+    considered = 0
+    hits = 0
+    failures: List[str] = []
+    for name, out in outputs.items():
+        msgs = out.get("messages")
+        if not isinstance(msgs, list) or not msgs:
+            failures.append(f"{name}: missing messages")
+            considered += 1
+            continue
+        if max_turns is not None and len(msgs) > max_turns:
+            failures.append(
+                f"{name}: expected <= {max_turns} turns, got {len(msgs)}"
+            )
+        exp_val = fixtures.get(name, {}).get("expected", {}).get(expected_field)
+        if exp_val is None:
+            # No ground truth provided; do not include in score
+            continue
+        considered += 1
+        got_val = msgs[-1].get(expected_field)
+        if got_val == exp_val and (
+            max_turns is None or len(msgs) <= max_turns
+        ):
+            hits += 1
+        else:
+            if got_val != exp_val:
+                failures.append(
+                    f"{name}: expected final {expected_field}={exp_val!r}, got {got_val!r}"
+                )
+    total = considered or 1
+    return hits / total, failures
+
+
+@register("conversation")
+def run(cfg, ev, outputs, fixtures):
+    if ev.expected_final_field is None:
+        raise ValueError("expected_final_field is required for conversation evaluator")
+    score, fails = evaluate(
+        outputs,
+        fixtures,
+        expected_field=ev.expected_final_field,
+        max_turns=ev.max_turns,
+    )
+    return score, fails, {}

--- a/tests/test_conversation_flow.py
+++ b/tests/test_conversation_flow.py
@@ -1,0 +1,42 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import conversation_flow as cf
+
+
+def test_conversation_flow_scoring_and_turns():
+    outputs = {
+        "a": {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "bye"},
+        ]},
+        "b": {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "nope"},
+        ]},
+        "c": {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "more"},
+            {"role": "assistant", "content": "final"},
+        ]},
+    }
+    fixtures = {
+        "a": {"expected": {"content": "bye"}},
+        "b": {"expected": {"content": "bye"}},
+        "c": {"expected": {"content": "final"}},
+    }
+    score, fails = cf.evaluate(outputs, fixtures, "content", max_turns=3)
+    assert round(score, 2) == 0.33
+    assert any("expected final content='bye'" in f for f in fails)
+    assert any("expected <= 3 turns" in f for f in fails)
+
+
+def test_conversation_flow_missing_messages():
+    outputs = {"a": {}}
+    fixtures = {"a": {"expected": {"content": "x"}}}
+    score, fails = cf.evaluate(outputs, fixtures, "content")
+    assert score == 0.0
+    assert len(fails) == 1


### PR DESCRIPTION
## Summary
- support a new `conversation` evaluator type with final message and turn limit configuration
- implement conversation flow evaluator to score conversations and register it with the CLI
- document conversation evaluator usage and add unit tests

## Testing
- `uv run ruff check src/evalgate/config.py src/evalgate/evaluators/conversation_flow.py src/evalgate/cli.py tests/test_conversation_flow.py`
- `uv run pytest tests/test_conversation_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6321a49ec832ba119c8b341ccaf07