### PR TITLE
Add tool usage evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ Or with the composite action:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
+## Tool Usage Logs
+
+Model outputs can record tool invocations to enable deterministic evaluation of agent behavior. Each output may include a `tool_calls` array with call `name` and `args` in the order executed:
+
+```json
+{
+  "output": "...",
+  "tool_calls": [
+    {"name": "search", "args": {"query": "foo"}},
+    {"name": "lookup", "args": {"id": 1}}
+  ]
+}
+```
+
+The `tool_usage` evaluator compares these logs against expected sequences via the `expected_tool_calls` config field.
+
 ## GitHub Actions Integration
 
 ### Option 1: Use the Composite Action

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -1,7 +1,7 @@
 
 from __future__ import annotations
 from enum import Enum
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -26,6 +26,7 @@ class EvaluatorType(str, Enum):
     ROUGE_BLEU = "rouge_bleu"
     REQUIRED_FIELDS = "required_fields"
     CLASSIFICATION = "classification"
+    TOOL_USAGE = "tool_usage"
 
 
 class EvaluatorCfg(BaseModel):
@@ -39,6 +40,7 @@ class EvaluatorCfg(BaseModel):
     pattern_field: Optional[str] = None  # name of expected field containing regex
     pattern_path: Optional[str] = None  # path to JSON mapping of name->regex
     multi_label: Optional[bool] = False  # treat field as list of labels
+    expected_tool_calls: Optional[Dict[str, List[Dict[str, Any]]]] = None  # expected tool call sequence
     # LLM-specific fields
     provider: Optional[str] = None  # "openai" | "anthropic" | "azure" | "local"
     model: Optional[str] = None  # e.g. "gpt-4", "claude-3-5-sonnet-20241022" or embedding model name

--- a/src/evalgate/evaluators/tool_usage.py
+++ b/src/evalgate/evaluators/tool_usage.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from .base import register
+
+
+def evaluate(
+    outputs: Dict[str, Dict[str, Any]],
+    expected: Dict[str, List[Dict[str, Any]]],
+) -> Tuple[float, List[str]]:
+    """Compare logged tool calls against expected sequences."""
+    considered = 0
+    hits = 0
+    fails: List[str] = []
+    for name, exp_calls in expected.items():
+        out = outputs.get(name, {})
+        calls = out.get("tool_calls") if isinstance(out, dict) else []
+        if not isinstance(calls, list):
+            calls = []
+        considered += 1
+        if len(calls) != len(exp_calls):
+            fails.append(
+                f"{name}: expected {len(exp_calls)} calls but got {len(calls)}"
+            )
+            continue
+        mismatch = False
+        for i, (exp, got) in enumerate(zip(exp_calls, calls)):
+            if exp.get("name") != got.get("name"):
+                fails.append(
+                    f"{name}[{i}]: expected tool {exp.get('name')!r} got {got.get('name')!r}"
+                )
+                mismatch = True
+                break
+            if exp.get("args") != got.get("args"):
+                fails.append(
+                    f"{name}[{i}]: expected args {exp.get('args')!r} got {got.get('args')!r}"
+                )
+                mismatch = True
+                break
+        if not mismatch:
+            hits += 1
+    total = considered or 1
+    return hits / total, fails
+
+
+@register("tool_usage")
+def run(cfg, ev, outputs, fixtures):
+    expected = ev.expected_tool_calls
+    if not expected:
+        raise ValueError("expected_tool_calls must be provided")
+    score, fails = evaluate(outputs, expected)
+    return score, fails, {}

--- a/tests/test_tool_usage.py
+++ b/tests/test_tool_usage.py
@@ -1,0 +1,55 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import tool_usage as tu
+
+
+def test_tool_usage_match():
+    outputs = {
+        "a": {
+            "tool_calls": [
+                {"name": "search", "args": {"q": "1"}},
+                {"name": "lookup", "args": {"id": 2}},
+            ]
+        }
+    }
+    expected = {
+        "a": [
+            {"name": "search", "args": {"q": "1"}},
+            {"name": "lookup", "args": {"id": 2}},
+        ]
+    }
+    score, fails = tu.evaluate(outputs, expected)
+    assert score == 1.0
+    assert fails == []
+
+
+def test_tool_usage_mismatch_args():
+    outputs = {
+        "a": {
+            "tool_calls": [
+                {"name": "search", "args": {"q": "1"}},
+                {"name": "lookup", "args": {"id": 2}},
+            ]
+        }
+    }
+    expected = {
+        "a": [
+            {"name": "search", "args": {"q": "1"}},
+            {"name": "lookup", "args": {"id": 3}},
+        ]
+    }
+    score, fails = tu.evaluate(outputs, expected)
+    assert score == 0.0
+    assert any("expected args" in f for f in fails)
+
+
+def test_tool_usage_mismatch_name():
+    outputs = {"a": {"tool_calls": [{"name": "search", "args": {}}]}}
+    expected = {"a": [{"name": "lookup", "args": {}}]}
+    score, fails = tu.evaluate(outputs, expected)
+    assert score == 0.0
+    assert any("expected tool" in f for f in fails)
+


### PR DESCRIPTION
## Summary
- document tool call logs and config for expected sequences
- add TOOL_USAGE evaluator comparing logged calls against expectations
- cover mismatched tool names and arguments with tests

## Testing
- `ruff check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a632328bd0832b9a0bd731f198972d