### PR TITLE
Add workflow DAG evaluator

### DIFF
--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -26,6 +26,7 @@ class EvaluatorType(str, Enum):
     ROUGE_BLEU = "rouge_bleu"
     REQUIRED_FIELDS = "required_fields"
     CLASSIFICATION = "classification"
+    WORKFLOW = "workflow"
 
 
 class EvaluatorCfg(BaseModel):
@@ -47,6 +48,7 @@ class EvaluatorCfg(BaseModel):
     base_url: Optional[str] = None  # for local/custom endpoints
     temperature: Optional[float] = 0.1  # for consistent evaluation
     max_tokens: Optional[int] = 1000  # response length limit
+    workflow_path: Optional[str] = None  # path to JSON or YAML workflow DAG spec
     enabled: bool = True
 
     @field_validator("type", mode="before")

--- a/src/evalgate/evaluators/workflow_dag.py
+++ b/src/evalgate/evaluators/workflow_dag.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+from .base import register
+
+
+def load_workflow(path: str) -> Dict[str, List[str]]:
+    """Load workflow DAG edges from JSON or YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        if path.endswith((".yaml", ".yml")):
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
+    edges = data.get("edges", {})
+    return edges
+
+
+def evaluate(outputs: Dict[str, Any], edges: Dict[str, List[str]]) -> Tuple[float, List[str]]:
+    """Verify that observed steps follow DAG edges.
+
+    Returns score and list of failures."""
+    nodes = set(edges.keys()) | {n for dests in edges.values() for n in dests}
+    observed_nodes = set()
+    fails: List[str] = []
+    for name, out in outputs.items():
+        seq: List[str] = []
+        if isinstance(out, dict):
+            seq = out.get("calls") or out.get("states") or []
+        if not isinstance(seq, list):
+            fails.append(f"{name}: missing calls/states list")
+            continue
+        for step in seq:
+            if step not in nodes:
+                fails.append(f"{name}: extra step {step}")
+        for a, b in zip(seq, seq[1:]):
+            if b not in edges.get(a, []):
+                fails.append(f"{name}: invalid transition {a}->{b}")
+        observed_nodes.update(seq)
+    missing = nodes - observed_nodes
+    for step in sorted(missing):
+        fails.append(f"missing step {step}")
+    score = 1.0 if not fails else 0.0
+    return score, fails
+
+
+@register("workflow")
+def run(cfg, ev, outputs, fixtures):
+    if not ev.workflow_path:
+        raise ValueError("workflow_path is required")
+    edges = load_workflow(ev.workflow_path)
+    score, fails = evaluate(outputs, edges)
+    return score, fails, {}

--- a/tests/data/workflow_dag.yaml
+++ b/tests/data/workflow_dag.yaml
@@ -1,0 +1,6 @@
+edges:
+  start:
+    - step1
+  step1:
+    - step2
+  step2: []

--- a/tests/test_workflow_dag.py
+++ b/tests/test_workflow_dag.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+import yaml
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from evalgate.evaluators import workflow_dag as wd
+
+
+def load_edges():
+    path = pathlib.Path(__file__).parent / "data" / "workflow_dag.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)["edges"]
+
+
+def test_workflow_valid():
+    edges = load_edges()
+    outputs = {"sample": {"calls": ["start", "step1", "step2"]}}
+    score, fails = wd.evaluate(outputs, edges)
+    assert score == 1.0
+    assert fails == []
+
+
+def test_workflow_invalid():
+    edges = load_edges()
+    outputs = {"sample": {"calls": ["start", "step2"]}}
+    score, fails = wd.evaluate(outputs, edges)
+    assert score == 0.0
+    assert any("invalid transition" in f for f in fails)
+    assert any("missing step step1" in f for f in fails)


### PR DESCRIPTION
## Summary
- support workflow DAG specs with new `WORKFLOW` evaluator type
- add evaluator to validate observed tool call order against DAG edges
- include example workflow spec and tests for valid/invalid paths

## Testing
- `ruff check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6324bf86c832bb89c4dabc30d31e7