### PR TITLE
Support nested seeding for conversation fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ uvx --from evalgate evalgate baseline update --config .github/evalgate.yml
 
 Pull requests will be compared against these baseline results.
 
+## Conversation Fixtures
+
+When working with chat-based models, fixtures can describe full conversations.
+Each conversation fixture contains a list of `messages`, where every message has
+a `role` (such as `system`, `user`, `assistant`, or `tool`) and `content`.
+Assistant messages may optionally include `tool_calls` describing functions the
+assistant wants to invoke.
+
+Example conversation fixture:
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "Hello!" },
+    {
+      "role": "assistant",
+      "content": "Hi there!",
+      "tool_calls": [
+        { "name": "search", "arguments": { "query": "Hello!" } }
+      ]
+    }
+  ]
+}
+```
+
 ## LLM as Judge
 
 EvalGate can use LLMs to evaluate outputs for complex criteria beyond simple schema validation.

--- a/src/evalgate/fixture_generator.py
+++ b/src/evalgate/fixture_generator.py
@@ -55,6 +55,17 @@ def _merge_seed(data: Any, seed: Any) -> Any:
         for k, v in seed.items():
             merged[k] = _merge_seed(data.get(k), v) if k in data else v
         return merged
+    if isinstance(seed, list) and isinstance(data, list):
+        merged_list: List[Any] = []
+        max_len = max(len(seed), len(data))
+        for i in range(max_len):
+            if i < len(seed) and i < len(data):
+                merged_list.append(_merge_seed(data[i], seed[i]))
+            elif i < len(seed):
+                merged_list.append(seed[i])
+            else:
+                merged_list.append(data[i])
+        return merged_list
     return seed
 
 

--- a/tests/fixtures/conversation.json
+++ b/tests/fixtures/conversation.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    { "role": "user", "content": "Hello!" },
+    {
+      "role": "assistant",
+      "content": "Hi there!",
+      "tool_calls": [
+        { "name": "search", "arguments": { "query": "Hello!" } }
+      ]
+    }
+  ]
+}

--- a/tests/test_fixture_generator_conversation.py
+++ b/tests/test_fixture_generator_conversation.py
@@ -1,0 +1,68 @@
+import json
+from evalgate.fixture_generator import generate_fixture
+from jsonschema import validate
+
+CONVERSATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "messages": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "role": {"type": "string", "enum": ["system", "user", "assistant", "tool"]},
+                    "content": {"type": "string"},
+                    "tool_calls": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "arguments": {
+                                    "type": "object",
+                                    "properties": {"query": {"type": "string"}},
+                                    "required": ["query"],
+                                },
+                            },
+                            "required": ["name", "arguments"],
+                        },
+                    },
+                },
+                "required": ["role", "content"],
+            },
+        }
+    },
+    "required": ["messages"],
+}
+
+
+def test_nested_seed_generation():
+    seed = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"name": "search", "arguments": {"query": "hi"}}],
+            },
+        ]
+    }
+    fixture = generate_fixture(CONVERSATION_SCHEMA, seed)
+
+    assert len(fixture["messages"]) == 2
+    assert fixture["messages"][0]["role"] == "user"
+    assert fixture["messages"][0]["content"] == "hi"
+    assert fixture["messages"][1]["role"] == "assistant"
+    assert "content" in fixture["messages"][1]
+    tc = fixture["messages"][1]["tool_calls"][0]
+    assert tc["name"] == "search"
+    assert tc["arguments"]["query"] == "hi"
+    validate(fixture, CONVERSATION_SCHEMA)
+
+
+def test_sample_fixture_loads(tmp_path):
+    with open("tests/fixtures/conversation.json", "r", encoding="utf-8") as f:
+        data = json.load(f)
+    validate(data, CONVERSATION_SCHEMA)
+    assert data["messages"][1]["tool_calls"][0]["name"] == "search"


### PR DESCRIPTION
## Summary
- allow fixture generator to merge seeded lists for nested structures like messages and tool calls
- document conversation fixture format and provide example
- add sample conversation fixture with tests

## Testing
- `ruff check src/evalgate/fixture_generator.py tests/test_fixture_generator_conversation.py`
- `PYTHONPATH=src pytest tests/test_fixture_generator_conversation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a632766170832b828b92662bb30ce3