### PR TITLE
feat: enforce per-evaluator min score thresholds

### DIFF
--- a/.github/evalgate.yml
+++ b/.github/evalgate.yml
@@ -4,7 +4,7 @@ fixtures: { path: "eval/fixtures/**/*.json" }
 outputs:  { path: ".evalgate/outputs/**/*.json" }
 evaluators:
   - { name: json_formatting, type: schema, schema_path: "eval/schemas/queue_item.json", weight: 0.3 }
-  - { name: priority_accuracy, type: category, expected_field: "priority", weight: 0.3 }
+  - { name: priority_accuracy, type: category, expected_field: "priority", weight: 0.3, min_score: 0.8 }
   - { name: latency_cost, type: budgets, weight: 0.2 }
   # Uncomment and configure with your API key to enable LLM evaluation:
   # - { name: content_quality, type: llm, provider: openai, model: "gpt-4", prompt_path: "eval/prompts/quality_judge.txt", api_key_env_var: "OPENAI_API_KEY", weight: 0.2 }

--- a/.github/workflows/evalgate.yml
+++ b/.github/workflows/evalgate.yml
@@ -25,6 +25,7 @@ jobs:
           python scripts/predict.py --in eval/fixtures --out .evalgate/outputs
 
       # Run EvalGate but don't fail the job yet (so we can always post a summary/comment)
+      # Per-evaluator score thresholds can be set via `min_score` in .github/evalgate.yml
       - name: Run EvalGate
         id: evalgate
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ evaluators:
     prompt_path: eval/prompts/quality_judge.txt
     api_key_env_var: OPENAI_API_KEY
     weight: 0.3
+    min_score: 0.75  # fail if score < 0.75
 ```
+
+`min_score` enforces a minimum evaluator score; the run fails if the score drops below this threshold.
 
 ### 4. Set your API key
 ```bash

--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -130,11 +130,21 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
             tables.append(extra["table"])
         if extra.get("plot") is not None:
             plots.append(extra["plot"])
-        score_item = {"name": ev.name, "score": float(s), "weight": ev.weight}
+        score_item = {
+            "name": ev.name,
+            "score": float(s),
+            "weight": ev.weight,
+            "min_score": ev.min_score,
+        }
         if extra.get("metrics") is not None:
             score_item["metrics"] = extra["metrics"]
+        score_item["passed"] = True if ev.min_score is None else s >= ev.min_score
         scores.append(score_item)
         failures.extend(v)
+        if not score_item["passed"]:
+            failures.append(
+                f"{ev.name}: score {s:.2f} < min_score {ev.min_score}"
+            )
 
     total_w = sum(x["weight"] for x in scores) or 1.0
     overall = sum(x["score"] * x["weight"] for x in scores) / total_w
@@ -156,10 +166,23 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
     if not evaluators_ok:
         rprint(f"[red]Gate failed: {len(evaluator_errors)} evaluator(s) failed to run[/red]")
     
-    passed = overall >= cfg.gate.min_overall_score and regression_ok and evaluators_ok
+    scores_ok = all(x["passed"] for x in scores)
+    passed = (
+        overall >= cfg.gate.min_overall_score
+        and regression_ok
+        and evaluators_ok
+        and scores_ok
+    )
     score_items = []
     for x in scores:
-        item = {"name": x["name"], "score": x["score"], "delta": deltas.get(x["name"])}
+        item = {
+            "name": x["name"],
+            "score": x["score"],
+            "delta": deltas.get(x["name"]),
+            "passed": x["passed"],
+        }
+        if x.get("min_score") is not None:
+            item["min_score"] = x["min_score"]
         if "metrics" in x:
             item["metrics"] = x["metrics"]
         score_items.append(item)
@@ -170,9 +193,14 @@ def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
         "evaluator_errors": evaluator_errors,  # Separate from test failures
         "latency": latency,
         "cost": cost,
-        "gate": {"min_overall_score": cfg.gate.min_overall_score, "allow_regression": cfg.gate.allow_regression, "passed": passed},
+        "gate": {
+            "min_overall_score": cfg.gate.min_overall_score,
+            "allow_regression": cfg.gate.allow_regression,
+            "passed": passed,
+        },
         "regression_ok": regression_ok,
         "evaluators_ok": evaluators_ok,
+        "scores_ok": scores_ok,
         "artifact_path": cfg.report.artifact_path,
         "tables": tables,
         "plots": plots,

--- a/src/evalgate/config.py
+++ b/src/evalgate/config.py
@@ -32,6 +32,7 @@ class EvaluatorCfg(BaseModel):
     name: str
     type: EvaluatorType
     weight: float = 1.0
+    min_score: float | None = None
     schema_path: Optional[str] = None
     expected_field: Optional[str] = None
     threshold: Optional[float] = 0.8  # cosine similarity threshold for embedding evaluator

--- a/src/evalgate/report.py
+++ b/src/evalgate/report.py
@@ -29,7 +29,13 @@ def render_markdown(result: Dict[str, Any], max_failures: int = 20) -> str:
         if delta is not None:
             deltas.append((item["name"], delta))
         delta_str = f" ({delta:+.2f} vs main)" if delta is not None else ""
-        lines.append(f"- {item['name']}: {item['score']:.2f}{delta_str}")
+        status = "✅" if item.get("passed", True) else "❌"
+        min_str = (
+            f" (min {item['min_score']:.2f})" if item.get("min_score") is not None else ""
+        )
+        lines.append(
+            f"- {item['name']}: {item['score']:.2f}{delta_str} → {status}{min_str}"
+        )
     if deltas:
         lines += ["", "**Baseline Deltas**"]
         lines.append("| Metric | Δ vs baseline |")
@@ -49,6 +55,7 @@ def render_markdown(result: Dict[str, Any], max_failures: int = 20) -> str:
         f"- min_overall_score: {result['gate']['min_overall_score']} → {'✅' if result['overall'] >= result['gate']['min_overall_score'] else '❌'}",
         f"- allow_regression: {result['gate']['allow_regression']} → {'✅' if (result.get('regression_ok', True)) else '❌'}",
         f"- evaluators_ok: → {'✅' if result.get('evaluators_ok', True) else '❌'}",
+        f"- scores_ok: → {'✅' if result.get('scores_ok', True) else '❌'}",
     ]
 
     # Optional tables (e.g., confusion matrices)

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -9,7 +9,15 @@ from evalgate.report import render_markdown
 def test_render_markdown_max_failures_and_plots():
     result = {
         "overall": 0.9,
-        "scores": [{"name": "metric1", "score": 0.9, "delta": 0.1}],
+        "scores": [
+            {
+                "name": "metric1",
+                "score": 0.9,
+                "delta": 0.1,
+                "passed": True,
+                "min_score": 0.5,
+            }
+        ],
         "failures": [f"f{i}" for i in range(6)],
         "evaluator_errors": [],
         "latency": None,
@@ -17,9 +25,11 @@ def test_render_markdown_max_failures_and_plots():
         "gate": {"min_overall_score": 0.5, "allow_regression": True, "passed": True},
         "regression_ok": True,
         "evaluators_ok": True,
+        "scores_ok": True,
         "plots": [{"title": "trend", "sparkline": "s.png", "url": "p.png"}],
     }
     md = render_markdown(result, max_failures=5)
     assert "… +1 more" in md
     assert "| Metric | Δ vs baseline |" in md
     assert "[![trend](s.png)](p.png)" in md
+    assert "- metric1: 0.90 (+0.10 vs main) → ✅ (min 0.50)" in md


### PR DESCRIPTION
## Summary
- add optional `min_score` to evaluator configuration
- fail runs when scores drop below their thresholds and expose pass/fail in results and markdown
- document `min_score` and update GitHub Action examples

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a632f8c37c832ba345de9bec1b89c2