### PR TITLE
feat: cache LLM judge responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ export OPENAI_API_KEY=your_api_key_here
 evalgate run --config .github/evalgate.yml
 ```
 
+LLM judge responses are cached in `.evalgate/cache.json`. Reuse cached results to avoid repeat API calls or clear them with:
+
+```bash
+evalgate run --config .github/evalgate.yml --clear-cache
+```
+
 ### GitHub Actions Integration with API Keys
 
 Add your API keys as repository secrets in GitHub, then use them in your workflow:

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,12 @@ runs:
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
         echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Cache LLM responses
+      uses: actions/cache@v4
+      with:
+        path: .evalgate/cache.json
+        key: ${{ runner.os }}-evalgate-${{ hashFiles('.evalgate/cache.json') }}
+        restore-keys: ${{ runner.os }}-evalgate-
     - name: Run EvalGate (PyPI)
       shell: bash
       env:

--- a/src/evalgate/cache.py
+++ b/src/evalgate/cache.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+CACHE_PATH = Path('.evalgate/cache.json')
+_cache: Dict[str, str] | None = None
+
+def _load() -> Dict[str, str]:
+    global _cache
+    if _cache is None:
+        if CACHE_PATH.exists():
+            try:
+                _cache = json.loads(CACHE_PATH.read_text(encoding='utf-8'))
+            except Exception:
+                _cache = {}
+        else:
+            _cache = {}
+    return _cache
+
+def _save() -> None:
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_PATH.write_text(json.dumps(_load(), indent=2), encoding='utf-8')
+
+def _key(model: str, prompt: str) -> str:
+    h = hashlib.sha256()
+    h.update(model.encode('utf-8'))
+    h.update(b'\x00')
+    h.update(prompt.encode('utf-8'))
+    return h.hexdigest()
+
+def get(model: str, prompt: str) -> Optional[str]:
+    return _load().get(_key(model, prompt))
+
+def set(model: str, prompt: str, response: str) -> None:
+    cache = _load()
+    cache[_key(model, prompt)] = response
+    _save()
+
+def clear() -> None:
+    global _cache
+    _cache = {}
+    if CACHE_PATH.exists():
+        CACHE_PATH.unlink()

--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -28,6 +28,7 @@ from .util import list_paths, read_json, write_json
 from .fixture_generator import generate_suite
 from .store import load_baseline
 from .report import render_markdown
+from . import cache
 from .templates import (
     load_default_config,
     load_schema_example, 
@@ -84,8 +85,11 @@ def generate_fixtures(
 
 @app.command()
 def run(config: str = typer.Option(..., help="Path to evalgate YAML"),
-        output: str = typer.Option(".evalgate/results.json", help="Where to write results JSON")):
+        output: str = typer.Option(".evalgate/results.json", help="Where to write results JSON"),
+        clear_cache: bool = typer.Option(False, "--clear-cache", help="Clear cached LLM responses before run")):
     """Run evals and write a results artifact."""
+    if clear_cache:
+        cache.clear()
     try:
         cfg = Config.model_validate(yaml.safe_load(pathlib.Path(config).read_text(encoding="utf-8")))
     except ValidationError as e:

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -52,3 +52,24 @@ def test_llm_judge_dependency_error(monkeypatch, tmp_path):
     )
     assert score == 0.0
     assert "Evaluation failed" in details[0]
+
+
+def test_llm_judge_cache(monkeypatch, tmp_path):
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("{input}")
+    calls = {"n": 0}
+
+    def fake_call(*args, **kwargs):
+        calls["n"] += 1
+        return "Score: 0.5"
+
+    monkeypatch.setattr(lj, "_call_openai", fake_call)
+    monkeypatch.setenv("OPENAI_KEY", "x")
+    from evalgate import cache
+
+    cache.clear()
+    outputs = {"a": {}}
+    fixtures = {"a": {}}
+    lj.evaluate(outputs, fixtures, provider="openai", model="gpt", prompt_path=str(prompt), api_key_env_var="OPENAI_KEY")
+    lj.evaluate(outputs, fixtures, provider="openai", model="gpt", prompt_path=str(prompt), api_key_env_var="OPENAI_KEY")
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- add cache module for storing LLM judge responses by model/prompt hash
- consult and persist cache in llm_judge evaluator and expose `--clear-cache` flag
- cache LLM responses in GitHub Action via `actions/cache`

## Testing
- `ruff check .`
- `yamllint action.yml` *(fails: existing style issues)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6331b4380832bb67c19a4e660f1c3