### PR TITLE
feat: add GitHub check run reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ uvx --from evalgate evalgate run --config .github/evalgate.yml
 
 # View results summary
 uvx --from evalgate evalgate report --summary --artifact .evalgate/results.json
+# Inside GitHub Actions, add --check-run to publish results as a check run
 ```
 
 ### 4. Update Baseline (optional)
@@ -130,6 +131,7 @@ Or with the composite action:
     config: .github/evalgate.yml
     openai_api_key: ${{ secrets.OPENAI_API_KEY }}
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    check_run: true
 ```
 
 ## GitHub Actions Integration
@@ -144,19 +146,26 @@ on: [pull_request]
 jobs:
   evalgate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      
+
       # Generate your model outputs
       - name: Generate outputs
         run: python scripts/predict.py --in eval/fixtures --out .evalgate/outputs
-      
+
       # Run EvalGate
       - uses: aotp-ventures/evalgate@main
         with:
           config: .github/evalgate.yml
+          check_run: true
 ```
+
+
+> **Note:** The workflow requires `checks: write` permission to publish the check run.
 
 ### Option 2: Direct Integration
 Or integrate directly in your existing workflow:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,3 @@
-
 name: "AOTP EvalGate"
 description: "Run deterministic LLM/RAG evals as a PR check"
 author: "AOTP Ventures"
@@ -17,6 +16,10 @@ inputs:
   azure_api_key:
     description: "Azure API key for LLM evaluators (optional)"
     required: false
+  check_run:
+    description: "Create a GitHub check run with results (optional)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -38,7 +41,11 @@ runs:
       if: always()
       shell: bash
       run: |
-        uvx --from evalgate evalgate report --summary --artifact ./.evalgate/results.json
+        args="--summary --artifact ./.evalgate/results.json"
+        if [[ "${{ inputs.check_run }}" == "true" ]]; then
+          args="$args --check-run"
+        fi
+        uvx --from evalgate evalgate report $args
     - name: Upload Results Artifact
       if: always()
       uses: actions/upload-artifact@v4
@@ -46,4 +53,3 @@ runs:
         name: evalgate-results
         path: .evalgate/results.json
         retention-days: 30
-

--- a/src/evalgate/cli.py
+++ b/src/evalgate/cli.py
@@ -6,6 +6,8 @@ import os
 import pathlib
 import random
 import subprocess
+import urllib.error
+import urllib.request
 import yaml
 import typer
 from pydantic import ValidationError
@@ -218,6 +220,11 @@ def report(
     summary: bool = typer.Option(False, "--summary", help="Write to $GITHUB_STEP_SUMMARY"),
     artifact: str = typer.Option(".evalgate/results.json", help="Path to results JSON"),
     max_failures: int = typer.Option(20, "--max-failures", help="Max failures to show"),
+    check_run: bool = typer.Option(
+        False,
+        "--check-run",
+        help="Create a GitHub check run with summary and annotations",
+    ),
 ):
     """Render a markdown summary from results."""
     data = read_json(artifact)
@@ -226,6 +233,54 @@ def report(
         pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text(md, encoding="utf-8")
     else:
         print(md)
+    if check_run:
+        token = os.environ.get('GITHUB_TOKEN')
+        sha = os.environ.get('GITHUB_SHA')
+        repo = os.environ.get('GITHUB_REPOSITORY')
+        if not (token and sha and repo):
+            rprint('[yellow]Missing GITHUB_TOKEN, GITHUB_SHA, or GITHUB_REPOSITORY for check run[/yellow]')
+        else:
+            annotations = []
+            for fail in data.get('failures', [])[:50]:
+                path = ''
+                msg = fail
+                if ':' in fail:
+                    name, msg_part = fail.split(':', 1)
+                    path = f'eval/fixtures/{name}.json'
+                    msg = msg_part.strip()
+                annotations.append({
+                    'path': path,
+                    'start_line': 1,
+                    'end_line': 1,
+                    'annotation_level': 'failure',
+                    'message': msg[:1000],
+                })
+            payload = {
+                'name': 'EvalGate',
+                'head_sha': sha,
+                'status': 'completed',
+                'conclusion': 'success' if data.get('gate', {}).get('passed') else 'failure',
+                'output': {
+                    'title': 'EvalGate',
+                    'summary': md[:65535],
+                    'annotations': annotations,
+                },
+            }
+            req = urllib.request.Request(
+                f'https://api.github.com/repos/{repo}/check-runs',
+                data=json.dumps(payload).encode('utf-8'),
+                headers={
+                    'Authorization': f'Bearer {token}',
+                    'Accept': 'application/vnd.github+json',
+                    'Content-Type': 'application/json',
+                    'User-Agent': 'evalgate',
+                },
+                method='POST',
+            )
+            try:
+                urllib.request.urlopen(req)
+            except urllib.error.URLError as e:
+                rprint(f'[yellow]Failed to create check run: {e}[/yellow]')
 
 def main():
     app()

--- a/tests/test_report_check_run.py
+++ b/tests/test_report_check_run.py
@@ -1,0 +1,28 @@
+import json
+import urllib.request
+
+from evalgate.cli import report
+
+
+def test_report_creates_check_run(tmp_path, monkeypatch):
+    data = {"overall": 0.5, "gate": {"passed": True, "min_overall_score": 0.0, "allow_regression": True}, "failures": ["fx1: bad"], "scores": [], "evaluator_errors": []}
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps(data))
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_SHA", "sha")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    captured = {}
+
+    def fake_urlopen(req):
+        captured["url"] = req.full_url
+        captured["payload"] = json.loads(req.data.decode())
+        class Resp:
+            pass
+        return Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    report(pr=False, summary=False, artifact=str(p), max_failures=20, check_run=True)
+    assert captured["url"].endswith("/repos/o/r/check-runs")
+    ann = captured["payload"]["output"]["annotations"][0]
+    assert ann["path"] == "eval/fixtures/fx1.json"
+    assert ann["annotation_level"] == "failure"


### PR DESCRIPTION
## Summary
- add `--check-run` option to `evalgate report` to publish results as a GitHub check run with per-fixture annotations
- make composite action optionally create check runs via new `check_run` input
- document check run usage and required `checks: write` permission

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6333aafb8832bbd2577ecec2bd49d