### PR TITLE
feat: expose eval results from action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: "Azure API key for LLM evaluators (optional)"
     required: false
 
+outputs:
+  total_score:
+    description: "Overall score from .evalgate/results.json"
+    value: ${{ steps.results.outputs.total_score }}
+  passed:
+    description: "Whether EvalGate passed"
+    value: ${{ steps.results.outputs.passed }}
+
 runs:
   using: "composite"
   steps:
@@ -34,6 +42,15 @@ runs:
         AZURE_API_KEY: ${{ inputs.azure_api_key }}
       run: |
         uvx --from evalgate[llm] evalgate run --config "${{ inputs.config }}"
+    - name: Read Results
+      id: results
+      if: always()
+      shell: bash
+      run: |
+        total_score=$(jq -r '.overall' .evalgate/results.json)
+        passed=$(jq -r '.gate.passed' .evalgate/results.json)
+        echo "total_score=$total_score" >> "$GITHUB_OUTPUT"
+        echo "passed=$passed" >> "$GITHUB_OUTPUT"
     - name: Summary
       if: always()
       shell: bash


### PR DESCRIPTION
## Summary
- surface total_score and passed outputs from composite action
- show how to gate downstream jobs using these outputs

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6334e76ec832bb77d97f4fb7c59b9