### PR TITLE
docs: fix outdated doc links

### DIFF
--- a/website/docs/v0.3.0/evaluators-reference.md
+++ b/website/docs/v0.3.0/evaluators-reference.md
@@ -403,7 +403,7 @@ Score: [your score]
 - **Caching:** Automatic response caching
 - **Retries:** Configurable retry logic
 
-**See [LLM as Judge Guide](06-llm-as-judge.md) for detailed documentation.**
+**See [LLM as Judge Guide](llm-as-judge.md) for detailed documentation.**
 
 ---
 
@@ -823,10 +823,10 @@ evaluators:
 
 ## Next Steps
 
-- **[Examples](10-examples.md)** - Real-world evaluator combinations
-- **[Best Practices](11-best-practices.md)** - Production deployment strategies  
-- **[CLI Reference](12-cli-reference.md)** - Command-line usage
-- **[Troubleshooting](13-troubleshooting.md)** - Debug common issues
+- **[Examples](examples.md)** - Real-world evaluator combinations
+- **[Best Practices](best-practices.md)** - Production deployment strategies
+- **[CLI Reference](cli-reference.md)** - Command-line usage
+- **[Troubleshooting](troubleshooting.md)** - Debug common issues
 
 ---
 

--- a/website/docs/v0.3.0/evaluators.md
+++ b/website/docs/v0.3.0/evaluators.md
@@ -455,10 +455,10 @@ Tailor evaluator combinations to your specific use case:
 
 ## Next Steps
 
-- **[Configuration Reference](04-configuration.md)** - Complete configuration options
-- **[Evaluators Reference](09-evaluators-reference.md)** - Detailed specifications for each type
-- **[Examples](10-examples.md)** - Real-world evaluator combinations
-- **[Best Practices](11-best-practices.md)** - Production deployment patterns
+- **[Configuration Reference](configuration.md)** - Complete configuration options
+- **[Evaluators Reference](evaluators-reference.md)** - Detailed specifications for each type
+- **[Examples](examples.md)** - Real-world evaluator combinations
+- **[Best Practices](best-practices.md)** - Production deployment patterns
 
 ---
 

--- a/website/docs/v0.3.0/fixtures.md
+++ b/website/docs/v0.3.0/fixtures.md
@@ -589,10 +589,10 @@ python scripts/enhance_fixtures.py \
 
 ## Next Steps
 
-- **[LLM as Judge](06-llm-as-judge.md)** - AI-powered evaluation setup
-- **[Examples](10-examples.md)** - Real-world fixture examples
-- **[CLI Reference](12-cli-reference.md)** - Complete fixture generation commands
-- **[Best Practices](11-best-practices.md)** - Production fixture strategies
+- **[LLM as Judge](llm-as-judge.md)** - AI-powered evaluation setup
+- **[Examples](examples.md)** - Real-world fixture examples
+- **[CLI Reference](cli-reference.md)** - Complete fixture generation commands
+- **[Best Practices](best-practices.md)** - Production fixture strategies
 
 ---
 

--- a/website/docs/v0.3.0/llm-as-judge.md
+++ b/website/docs/v0.3.0/llm-as-judge.md
@@ -636,10 +636,10 @@ EVALGATE_LOG_LEVEL=DEBUG evalgate run --config .github/evalgate.yml
 
 ## Next Steps
 
-- **[GitHub Integration](07-github-integration.md)** - Advanced CI/CD patterns
-- **[Baseline Management](08-baseline-management.md)** - Progressive quality improvement
-- **[Examples](10-examples.md)** - Real-world LLM judge implementations
-- **[Best Practices](11-best-practices.md)** - Production deployment strategies
+- **[GitHub Integration](github-integration.md)** - Advanced CI/CD patterns
+- **[Baseline Management](baseline-management.md)** - Progressive quality improvement
+- **[Examples](examples.md)** - Real-world LLM judge implementations
+- **[Best Practices](best-practices.md)** - Production deployment strategies
 
 ---
 


### PR DESCRIPTION
## Summary
- fix old numeric-prefixed links in docs

## Testing
- `npm run lint`
- `npm run build` (fails: Failed to fetch font file from `fonts.gstatic.com`)


------
https://chatgpt.com/codex/tasks/task_e_68a68c5dff84832b978593f22318a94c