### PR TITLE
docs: add quick run instructions

### DIFF
--- a/website/docs/v0.3.0/quick-start.md
+++ b/website/docs/v0.3.0/quick-start.md
@@ -12,6 +12,14 @@ Get EvalGate v0.3.0 running in your project in under 10 minutes. Zero infrastruc
 
 This guide assumes you have a GitHub repository and can run Python scripts.
 
+## Quick Run
+
+```bash
+evalgate init
+python scripts/predict.py --in eval/fixtures --out .evalgate/outputs
+evalgate run --config .github/evalgate.yml
+```
+
 ## What You'll Build
 
 By the end of this guide, you'll have:


### PR DESCRIPTION
## Summary
- add a quick run section to the v0.3.0 quick-start guide

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68c799108832ba7ff2c94c6b8e4ee