### PR TITLE
chore: expand evalgate budgets block

### DIFF
--- a/.github/evalgate.yml
+++ b/.github/evalgate.yml
@@ -1,5 +1,7 @@
 # See README for full reference
-budgets: { p95_latency_ms: 1200, max_cost_usd_per_item: 0.03 }
+budgets:
+  p95_latency_ms: 1200
+  max_cost_usd_per_item: 0.03
 fixtures: { path: "eval/fixtures/**/*.json" }
 outputs:  { path: ".evalgate/outputs/**/*.json" }
 evaluators:


### PR DESCRIPTION
## Summary
- format budgets block explicitly in `.github/evalgate.yml`

## Testing
- `uv run ruff check .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a68c813b0c832bab8ddc55e125e4a0