### PR TITLE
docs: clarify latency cost fixture requirements

### DIFF
--- a/website/docs/v0.3.0/evaluators.md
+++ b/website/docs/v0.3.0/evaluators.md
@@ -367,6 +367,8 @@ fixture's `expected` object appear in the model output.
 ### Latency/Cost Evaluator
 Performance budget enforcement.
 
+**Note:** Each fixture's `meta` section must include `latency_ms` and `cost_usd` values for this evaluator to work.
+
 **Configuration:**
 ```yaml
 - name: performance


### PR DESCRIPTION
## Summary
- document that Latency/Cost evaluator requires `latency_ms` and `cost_usd` in each fixture's `meta`

## Testing
- `uv run ruff check .`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a692c2a304832ba518b40a32c80005