### PR TITLE
docs: add conversation flow example

### DIFF
--- a/website/docs/v0.3.0/evaluators.md
+++ b/website/docs/v0.3.0/evaluators.md
@@ -304,6 +304,27 @@ Multi-turn dialogue validation.
   weight: 0.3
 ```
 
+**Example Fixture & Output:**
+
+Fixture:
+```json
+{
+  "expected": {"content": "4"}
+}
+```
+
+Output:
+```json
+{
+  "messages": [
+    {"role": "user", "content": "What is 2 + 2?"},
+    {"role": "assistant", "content": "4"}
+  ]
+}
+```
+
+With `expected_final_field: "content"`, the evaluator compares `expected.content` against the `content` of the final message in `messages`.
+
 **Use Cases:** Chatbots, dialogue systems, conversational AI
 
 ### Tool Usage Evaluator


### PR DESCRIPTION
## Summary
- add example conversation fixture and output for conversation flow evaluator

## Testing
- `uv run ruff check .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a692cb2cb4832bab5f188d2c129764