### PR TITLE
docs: mention rouge/bleu dependencies

### DIFF
--- a/website/docs/v0.3.0/evaluators.md
+++ b/website/docs/v0.3.0/evaluators.md
@@ -281,6 +281,8 @@ Semantic similarity using sentence transformers.
 ### ROUGE/BLEU Evaluator
 Standard text generation quality metrics.
 
+**Dependencies:** `sacrebleu` and `rouge-score` (install with `pip install sacrebleu rouge-score`)
+
 **Configuration:**
 ```yaml
 - name: text_quality


### PR DESCRIPTION
## Summary
- document `sacrebleu` and `rouge-score` dependencies for ROUGE/BLEU evaluator

## Testing
- `npm run lint`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a692d9a0bc832ba4f0088cbc7ce4d8